### PR TITLE
Removed redundant vendor specific rules

### DIFF
--- a/nprogress.css
+++ b/nprogress.css
@@ -1,7 +1,6 @@
 /* Make clicks pass-through */
 #nprogress {
   pointer-events: none;
-  -webkit-pointer-events: none;
 }
 
 #nprogress .bar {
@@ -27,10 +26,8 @@
   opacity: 1.0;
 
   -webkit-transform: rotate(3deg) translate(0px, -4px);
-  -moz-transform: rotate(3deg) translate(0px, -4px);
-  -ms-transform: rotate(3deg) translate(0px, -4px);
-  -o-transform: rotate(3deg) translate(0px, -4px);
-  transform: rotate(3deg) translate(0px, -4px);
+      -ms-transform: rotate(3deg) translate(0px, -4px);
+          transform: rotate(3deg) translate(0px, -4px);
 }
 
 /* Remove these to get rid of the spinner */
@@ -46,36 +43,21 @@
   width: 14px;
   height: 14px;
 
-  border:  solid 2px transparent;
-  border-top-color:  #29d;
+  border: solid 2px transparent;
+  border-top-color: #29d;
   border-left-color: #29d;
   border-radius: 10px;
 
   -webkit-animation: nprogress-spinner 400ms linear infinite;
-  -moz-animation:    nprogress-spinner 400ms linear infinite;
-  -ms-animation:     nprogress-spinner 400ms linear infinite;
-  -o-animation:      nprogress-spinner 400ms linear infinite;
-  animation:         nprogress-spinner 400ms linear infinite;
+          animation: nprogress-spinner 400ms linear infinite;
 }
 
 @-webkit-keyframes nprogress-spinner {
-  0%   { -webkit-transform: rotate(0deg);   transform: rotate(0deg); }
-  100% { -webkit-transform: rotate(360deg); transform: rotate(360deg); }
-}
-@-moz-keyframes nprogress-spinner {
-  0%   { -moz-transform: rotate(0deg);   transform: rotate(0deg); }
-  100% { -moz-transform: rotate(360deg); transform: rotate(360deg); }
-}
-@-o-keyframes nprogress-spinner {
-  0%   { -o-transform: rotate(0deg);   transform: rotate(0deg); }
-  100% { -o-transform: rotate(360deg); transform: rotate(360deg); }
-}
-@-ms-keyframes nprogress-spinner {
-  0%   { -ms-transform: rotate(0deg);   transform: rotate(0deg); }
-  100% { -ms-transform: rotate(360deg); transform: rotate(360deg); }
+  0%   { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
 }
 @keyframes nprogress-spinner {
-  0%   { transform: rotate(0deg);   transform: rotate(0deg); }
-  100% { transform: rotate(360deg); transform: rotate(360deg); }
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 


### PR DESCRIPTION
Tested in Chrome, Safari, Firefox, Opera and it should work in IE.. could test it tomorrow!

Here you can see that is pretty safe to remove the `-moz` and `-o` and most of the animations:
- http://caniuse.com/css-animation
- http://caniuse.com/transforms2d
- http://caniuse.com/pointer-events

P.S. Awesome project...
