### PR TITLE
Added box-sizing: border-box to the icon and increased the size

### DIFF
--- a/nprogress.css
+++ b/nprogress.css
@@ -43,8 +43,9 @@
 }
 
 #nprogress .spinner-icon {
-  width: 14px;
-  height: 14px;
+  width: 18px;
+  height: 18px;
+  box-sizing: border-box;
 
   border:  solid 2px transparent;
   border-top-color:  #29d;


### PR DESCRIPTION
The result is exactly the same as it was but now you can control the width/height of the icon without caring about the thickness of the borders
