### PR TITLE
Add support for showing/hiding the spinner independently from the progre...

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -163,6 +163,26 @@
     return NProgress.inc(Math.random() * Settings.trickleRate);
   };
 
+  /* 
+   * Shows the spinner independently from the progress bar.
+   */
+  NProgress.showSpinner = function () {
+    
+    var $el = NProgress.render();
+    $el.find('[role="spinner"]').show();
+    
+  };
+  
+  /*
+   * Hides the spinner independently from the progress bar.
+   */
+  NProgress.hideSpinner = function () {
+    
+    var $el = NProgress.render();
+    $el.find('[role="spinner"]').hide();
+    
+  };
+
   /**
    * (Internal) renders the progress bar markup based on the `template`
    * setting.
@@ -183,7 +203,7 @@
     });
 
     if (!Settings.showSpinner)
-      $el.find('[role="spinner"]').remove();
+      $el.find('[role="spinner"]').hide();
 
     $el.appendTo(document.body);
 


### PR DESCRIPTION
We're using nprogress in our app, and we had cases where we wanted to show the spinner but not the progress bar, and vice-versa. This pull requests adds two functions (showSpinner and hideSpinner) to show the spinner independently of the progress bar. 

I can add tests (and fix the existing, failing cases) if you are interested in merging this.
