### PR TITLE
Removed translate from .peg and made it a bit more visible

### DIFF
--- a/nprogress.css
+++ b/nprogress.css
@@ -20,14 +20,15 @@
   display: block;
   position: absolute;
   right: 0px;
+  top: -3px;
   width: 100px;
   height: 100%;
   box-shadow: 0 0 10px #29d, 0 0 5px #29d;
   opacity: 1.0;
 
-  -webkit-transform: rotate(3deg) translate(0px, -4px);
-      -ms-transform: rotate(3deg) translate(0px, -4px);
-          transform: rotate(3deg) translate(0px, -4px);
+  -webkit-transform: rotate(3deg);
+      -ms-transform: rotate(3deg);
+          transform: rotate(3deg);
 }
 
 /* Remove these to get rid of the spinner */


### PR DESCRIPTION
The `.peg` is a bit more visible by putting it a bit lower that where it was and without using the `translate`.

You can check the suggested demo here:
https://dl.dropboxusercontent.com/u/15234/nprogress/nprogress/index.html

In the screenshots below I have changed the shadow color to red to demonstrate better the change.

The original:
![original](https://f.cloud.github.com/assets/125676/1091938/54ec53e0-1671-11e3-8d84-b5f5280978c1.png)

The suggested:
![suggested](https://f.cloud.github.com/assets/125676/1091939/57e76f62-1671-11e3-9a84-2b6ae0f76351.png)
