### PR TITLE
added NProgress.promise

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -164,6 +164,42 @@
   };
 
   /**
+   * Waits for all supplied jQuery promises and
+   * increases the progress as the promises resolve.
+   * 
+   * @param $promise jQUery Promise
+   */
+  (function() {
+    var initial = 0, current = 0;
+    
+    NProgress.promise = function($promise) {
+      if (!$promise || $promise.state() == "resolved") {
+        return this;
+      }
+      
+      if (current == 0) {
+        NProgress.start();
+      }
+      
+      initial++;
+      current++;
+      
+      $promise.always(function() {
+        current--;
+        if (current == 0) {
+            initial = 0;
+            NProgress.done();
+        } else {
+            NProgress.set((initial - current) / initial);
+        }
+      });
+      
+      return this;
+    };
+    
+  })();
+
+  /**
    * (Internal) renders the progress bar markup based on the `template`
    * setting.
    */


### PR DESCRIPTION
An easy way to push some jQuery promises to NProgress. NProgress will then start, if not already running, and wait for each promise to finish. While the promises resolve, NProgress updates its state based on the amount of supplied and finished promises.
