### PR TITLE
Blur effects by pseudo-elements and border-radius

### DIFF
--- a/nprogress.css
+++ b/nprogress.css
@@ -16,7 +16,8 @@
 }
 
 /* Fancy blur effect */
-#nprogress .peg {
+#nprogress .bar:after {
+  content: " ";
   display: block;
   position: absolute;
   right: 0px;

--- a/nprogress.css
+++ b/nprogress.css
@@ -21,14 +21,11 @@
   display: block;
   position: absolute;
   right: 0px;
-  width: 100px;
+  width: 120px;
   height: 100%;
-  box-shadow: 0 0 10px #29d, 0 0 5px #29d;
+  border-bottom-left-radius: 100px 2px;
+  box-shadow: 2px 0 5px #29d;
   opacity: 1.0;
-
-  -webkit-transform: rotate(3deg) translate(0px, -4px);
-      -ms-transform: rotate(3deg) translate(0px, -4px);
-          transform: rotate(3deg) translate(0px, -4px);
 }
 
 /* Remove these to get rid of the spinner */

--- a/nprogress.js
+++ b/nprogress.js
@@ -27,7 +27,7 @@
     trickleRate: 0.02,
     trickleSpeed: 800,
     showSpinner: true,
-    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
+    template: '<div class="bar" role="bar"></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
   };
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,6 @@
         NProgress.set(0);
         assert.equal($("#nprogress").length, 1);
         assert.equal($("#nprogress .bar").length, 1);
-        assert.equal($("#nprogress .peg").length, 1);
         assert.equal($("#nprogress .spinner").length, 1);
         done();
       });


### PR DESCRIPTION
- Use pseudo elements instead of `div.peg` to take blur effect, ie8+ support
- Fade blur effect by `border-radius` instead of `transform:rotate`, `border-radius` has better compatibility

Before:
![2013-10-18 1 07 44](https://f.cloud.github.com/assets/1676871/1358198/03a2fa78-37b6-11e3-92f8-3ce97c215927.png)

After:
![2013-10-18 1 08 35](https://f.cloud.github.com/assets/1676871/1358200/07db0572-37b6-11e3-8f89-1abc0802baae.png)
