### PR TITLE
dependencies -> devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "./node_modules/.bin/mocha -R spec"
   },
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "chai": "~1.6.1",
     "mocha": "~1.11.0",
     "jsdom": "~0.6.5"


### PR DESCRIPTION
See https://npmjs.org/doc/files/package.json.html#devDependencies

> If someone is planning on downloading and using your module in their program, then they probably don't want or need to download and build the external test or documentation framework that you use.
> 
> In this case, it's best to list these additional items in a devDependencies hash.

:smile: 
