### PR TITLE
Add support for container other than body

### DIFF
--- a/nprogress.css
+++ b/nprogress.css
@@ -6,7 +6,7 @@
 #nprogress .bar {
   background: #29d;
 
-  position: fixed;
+  position: fixed; /* set this to absolute to use with a containerElement */
   z-index: 100;
   top: 0;
   left: 0;
@@ -33,7 +33,7 @@
 /* Remove these to get rid of the spinner */
 #nprogress .spinner {
   display: block;
-  position: fixed;
+  position: fixed; /* set this to absolute to use with a containerElement */
   z-index: 100;
   top: 15px;
   right: 15px;

--- a/nprogress.js
+++ b/nprogress.js
@@ -27,7 +27,8 @@
     trickleRate: 0.02,
     trickleSpeed: 800,
     showSpinner: true,
-    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
+    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>',
+    containerElement: undefined
   };
 
   /**
@@ -166,24 +167,24 @@
   /**
    * Waits for all supplied jQuery promises and
    * increases the progress as the promises resolve.
-   * 
+   *
    * @param $promise jQUery Promise
    */
   (function() {
     var initial = 0, current = 0;
-    
+
     NProgress.promise = function($promise) {
       if (!$promise || $promise.state() == "resolved") {
         return this;
       }
-      
+
       if (current == 0) {
         NProgress.start();
       }
-      
+
       initial++;
       current++;
-      
+
       $promise.always(function() {
         current--;
         if (current == 0) {
@@ -193,10 +194,10 @@
             NProgress.set((initial - current) / initial);
         }
       });
-      
+
       return this;
     };
-    
+
   })();
 
   /**
@@ -221,7 +222,7 @@
     if (!Settings.showSpinner)
       $el.find('[role="spinner"]').remove();
 
-    $el.appendTo(document.body);
+    $el.appendTo(Settings.containerElement || document.body);
 
     return $el;
   };


### PR DESCRIPTION
Supplying a containerElement property in the configuration allows you to attach the loader to an element other than the main body.
