### PR TITLE
remove() should reset the status to null

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -233,6 +233,7 @@
   NProgress.remove = function() {
     $('html').removeClass('nprogress-busy');
     $('#nprogress').remove();
+    NProgress.status = null;
   };
 
   /**


### PR DESCRIPTION
Otherwise, if you use remove() straight away (which I did because I didn't want to have the done() smooth ending animation), the inc() timers are still firing and make the bar show up again; because the NProgress status is not set back to is initial state (null)

This is addressing that issue
