### PR TITLE
Upped z-index to work better with Bootstrap nav

### DIFF
--- a/nprogress.css
+++ b/nprogress.css
@@ -7,7 +7,7 @@
   background: #29d;
 
   position: fixed;
-  z-index: 100;
+  z-index: 1031;
   top: 0;
   left: 0;
 
@@ -34,7 +34,7 @@
 #nprogress .spinner {
   display: block;
   position: fixed;
-  z-index: 100;
+  z-index: 1031;
   top: 15px;
   right: 15px;
 }


### PR DESCRIPTION
If z-index is upped to 1031 for .bar and .spinner, nprogress will work out of the box with Bootstrap 3.x's nav, which is z-index:1030.
