### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Rico Sta. Cruz
+Copyright (c) 2013-2014 Rico Sta. Cruz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ03.pdf for more info
