### PR TITLE
stronger check on module

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -3,7 +3,7 @@
 
 ;(function(factory) {
 
-  if (typeof module === 'function') {
+  if (typeof module !== 'undefined' && module.exports) {
     module.exports = factory();
   } else if (typeof define === 'function' && define.amd) {
     define(factory);


### PR DESCRIPTION
karma uses `module` as a function as well, but `NProgress` should live in the window object if it's run by karma.

from http://addyosmani.com/writing-modular-js/
