### PR TITLE
Use correct 'main' file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
      "type": "git",
      "url": "https://github.com/rstacruz/nprogress.git"
   },
+  "main": "./nprogress.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha -R spec"
   },


### PR DESCRIPTION
The `package.json` file doesn't contain the correct 'main' field which means that you can't just `require('nprogress')`. This PR will resolve this.
