### PR TITLE
Add support for specifying parent container

### DIFF
--- a/nprogress.css
+++ b/nprogress.css
@@ -53,6 +53,16 @@
           animation: nprogress-spinner 400ms linear infinite;
 }
 
+.nprogress-custom-parent {
+  overflow: hidden;
+  position: relative;
+}
+
+.nprogress-custom-parent #nprogress .spinner,
+.nprogress-custom-parent #nprogress .bar {
+  position: absolute;
+}
+
 @-webkit-keyframes nprogress-spinner {
   0%   { -webkit-transform: rotate(0deg); }
   100% { -webkit-transform: rotate(360deg); }

--- a/nprogress.js
+++ b/nprogress.js
@@ -27,6 +27,7 @@
     showSpinner: true,
     barSelector: '[role="bar"]',
     spinnerSelector: '[role="spinner"]',
+    parent: 'body',
     template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
   };
 
@@ -226,6 +227,7 @@
 
     var bar      = progress.querySelector(Settings.barSelector),
         perc     = fromStart ? '-100' : toBarPerc(NProgress.status || 0),
+        parent   = document.querySelector(Settings.parent),
         spinner;
     
     css(bar, {
@@ -238,7 +240,11 @@
       spinner && removeElement(spinner);
     }
 
-    document.body.appendChild(progress);
+    if (parent != document.body) {
+      addClass(parent, 'nprogress-custom-parent');
+    }
+
+    parent.appendChild(progress);
     return progress;
   };
 
@@ -248,6 +254,7 @@
 
   NProgress.remove = function() {
     removeClass(document.documentElement, 'nprogress-busy');
+    removeClass(document.querySelector(Settings.parent), 'nprogress-custom-parent')
     var progress = document.getElementById('nprogress');
     progress && removeElement(progress);
   };

--- a/support/style.css
+++ b/support/style.css
@@ -3,6 +3,11 @@ i, b {
   font-weight: 400;
 }
 
+body, html {
+  padding: 0;
+  margin: 0;
+}
+
 body {
   background: white;
 }
@@ -130,11 +135,10 @@ button {
 }
 
 .page-header {
-  margin: 1.5em auto;
   text-align: center;
   max-width: 400px;
-  padding: 0 20px;
-  margin: 3em auto;
+  padding: 3em 20px;
+  margin: 0 auto;
 }
 
 .page-header h1 {
@@ -173,7 +177,7 @@ p.brief.big {
   .page-header h1 {
     font-size: 3em; }
   .page-header {
-    margin: 4.5em auto 3.5em auto;
+    padding: 4.5em 20px 3.5em 20px;
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,14 @@
         NProgress.start();
         assert.equal(NProgress.status, NProgress.settings.minimum);
       });
+
+      it('must be attached to specified parent', function() {
+        var test = $('<div>', {id: 'test'}).appendTo('body');
+        NProgress.configure({parent: '#test'});
+        NProgress.start();
+        assert.isTrue($("#nprogress").parent().is(test));
+        assert.isTrue($(NProgress.settings.parent).hasClass("nprogress-custom-parent"));
+      });
     });
 
     // ----
@@ -88,6 +96,19 @@
         done();
       });
     });
+
+    // ----
+
+    describe('.remove()', function() {
+      it('should be removed from the parent', function() {
+        NProgress.set(1);
+        NProgress.remove();
+
+        var parent = $(NProgress.settings.parent);
+        assert.isFalse(parent.hasClass('nprogress-custom-parent'));
+        assert.equal(parent.find('#nprogress').length, 0);
+      });
+    })
 
     // ----
 


### PR DESCRIPTION
This PR addresses @rstacruz' comments from #33 and updated it to work without the jQuery dependency. 

Good idea on adding a conditional class to avoid having to adjust css values. 

I opted to keep the `parent` option because I feel code ought to be self-documenting, and one of the first things I look for when reading a piece of code is look for the options hash. Having the default just be 'body' specified in string form implies you just need a CSS selector. I think atleast :smile:, I don't mind removing it if you'd prefer though.
