### PR TITLE
feat(package): add support for jspm package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,16 @@
     "mocha": "~1.11.0",
     "mocha-jsdom": "^0.1.1"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "jspm": { 
+    "format": "global", 
+    "shim": { 
+      "nprogress": { 
+        "deps": ["./nprogress.css!"] 
+      } 
+    }, 
+    "dependencies": { 
+      "css": "*" 
+    } 
+  }
 }


### PR DESCRIPTION
This commit adds a custom section to the package.json file in order to support the [jspm](http://jspm.io/) package manager. By adding this information the package manager will now be able to correctly install the package for use with the system.js ES6 module loader using the simple command `jspm install github:rstacruz/nprogress` Developers eager to leverage nprogress via jspm won't have to worry about css dependencies or shim configuration. Everything will work automatically.