### PR TITLE
Add spm support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,13 +15,14 @@ Add [nprogress.js] and [nprogress.css] to your project.
 <link rel='stylesheet' href='nprogress.css'/>
 ```
 
-NProgress is available via [bower] and [npm].
+NProgress is available via [bower] and [npm] and [spm].
 
     $ bower install --save nprogress
     $ npm install --save nprogress
 
 [bower]: http://bower.io/search/?q=nprogress
 [npm]: https://www.npmjs.org/package/nprogress
+[spm]: http://spmjs.io/package/nprogress
 
 Basic usage
 -----------
@@ -193,3 +194,4 @@ Authored and maintained by Rico Sta. Cruz with help from [contributors].
 
 [![Status](https://api.travis-ci.org/rstacruz/nprogress.svg?branch=master)](http://travis-ci.org/rstacruz/nprogress) 
 [![npm version](https://img.shields.io/npm/v/nprogress.png)](https://npmjs.org/package/nprogress "View this project on npm")
+[![spm package](http://spmjs.io/badge/nprogress)](http://spmjs.io/package/nprogress)

--- a/package.json
+++ b/package.json
@@ -20,15 +20,24 @@
     "mocha-jsdom": "^0.1.1"
   },
   "dependencies": {},
-  "jspm": { 
-    "format": "global", 
-    "shim": { 
-      "nprogress": { 
-        "deps": ["./nprogress.css!"] 
-      } 
-    }, 
-    "dependencies": { 
-      "css": "*" 
-    } 
+  "jspm": {
+    "format": "global",
+    "shim": {
+      "nprogress": {
+        "deps": ["./nprogress.css!"]
+      }
+    },
+    "dependencies": {
+      "css": "*"
+    }
+  },
+  "spm": {
+    "main": "nprogress.js",
+    "output": ["nprogress.css"],
+    "ignore": [
+      "support",
+      "test",
+      "vendor"
+    ]
   }
 }


### PR DESCRIPTION
A nice package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/nprogress

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of nprogress in spmjs, I would like add it for your account after signing in http://spmjs.io.

spmjs/spm#781