### PR TITLE
Add config for right-to-left progress (for RTL languages)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -155,6 +155,13 @@ specify this to change the parent container. (default: `body`)
 NProgress.configure({ parent: '#container' });
 ~~~
 
+#### `rtl`
+Change the progress direction to right-to-left. (default: `false`)
+
+~~~ js
+NProgress.configure({ rtl: true });
+~~~
+
 Customization
 -------------
 

--- a/nprogress.js
+++ b/nprogress.js
@@ -24,6 +24,7 @@
     trickle: true,
     trickleSpeed: 250,
     showSpinner: true,
+    rtl: false,
     barSelector: '[role="bar"]',
     spinnerSelector: '[role="spinner"]',
     parent: 'body',
@@ -242,7 +243,7 @@
     progress.innerHTML = Settings.template;
 
     var bar      = progress.querySelector(Settings.barSelector),
-        perc     = fromStart ? '-100' : toBarPerc(NProgress.status || 0),
+        perc     = fromStart ? toBarPerc(0) : toBarPerc(NProgress.status || 0),
         parent   = document.querySelector(Settings.parent),
         spinner;
 
@@ -325,6 +326,7 @@
    */
 
   function toBarPerc(n) {
+    if (NProgress.settings.rtl) return (1 - n) * 100;
     return (-1 + n) * 100;
   }
 


### PR DESCRIPTION
To properly support RTL languages like Hebrew, the progress should be able to animate right-to-left.

This adds an option to configure the progress bar to be RTL:
#### `rtl`

Change the progress direction to right-to-left. (default: `false`)

``` js
NProgress.configure({ rtl: true });
```
