### PR TITLE
Added config param topPosition to enable setting a custom top position on the fly.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -169,6 +169,13 @@ specify this to change the parent container. (default: `body`)
 NProgress.configure({ parent: '#container' });
 ~~~
 
+### `topPosition`
+Configure this to change the top position of the bar. (default: `0`)
+
+~~~ js
+NProgress.configure({ topPosition: 20 });
+~~~
+
 Customization
 -------------
 

--- a/Readme.md
+++ b/Readme.md
@@ -169,7 +169,7 @@ specify this to change the parent container. (default: `body`)
 NProgress.configure({ parent: '#container' });
 ~~~
 
-### `topPosition`
+#### `topPosition`
 Configure this to change the top position of the bar. (default: `0`)
 
 ~~~ js

--- a/nprogress.js
+++ b/nprogress.js
@@ -27,7 +27,8 @@
     barSelector: '[role="bar"]',
     spinnerSelector: '[role="spinner"]',
     parent: 'body',
-    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
+    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>',
+	topPosition: '0'
   };
 
   /**
@@ -79,6 +80,10 @@
 
       // Add transition
       css(bar, barPositionCSS(n, speed, ease));
+	  
+	  css(bar, {
+		  top: Settings.topPosition
+	  });
 
       if (n === 1) {
         // Fade out

--- a/nprogress.js
+++ b/nprogress.js
@@ -28,7 +28,7 @@
     spinnerSelector: '[role="spinner"]',
     parent: 'body',
     template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>',
-	topPosition: '0'
+    topPosition: '0'
   };
 
   /**
@@ -80,10 +80,9 @@
 
       // Add transition
       css(bar, barPositionCSS(n, speed, ease));
-	  
-	  css(bar, {
-		  top: Settings.topPosition
-	  });
+      
+      // Set position from top
+      css(bar, { top: Settings.topPosition });
 
       if (n === 1) {
         // Fade out


### PR DESCRIPTION
Using this config option, the position of the progress bar can be configured based on the position of some other container. It can be changed on the fly to render at a certain position. In my [project](http://lifeinweeks-ghax.rhcloud.com/) I wanted to align the progress bar with the underline on the word "weeks". Even on scrolling, I can make the progress bar to coincide with the underline on "weeks". If the weeks underline is scrolled over the screen, it renders at the default position (0px).

![screenshot 1](https://cloud.githubusercontent.com/assets/971048/18256310/39cbcb8e-73d1-11e6-8bf6-318cc3a22ef0.PNG)

![screenshot 2](https://cloud.githubusercontent.com/assets/971048/18256321/635080bc-73d1-11e6-8388-6090e9dfb2ac.PNG)
