### PR TITLE
Allow passing in an alternate scheduler function

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -27,7 +27,8 @@
     barSelector: '[role="bar"]',
     spinnerSelector: '[role="spinner"]',
     parent: 'body',
-    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
+    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>',
+    scheduler: window.setTimeout
   };
 
   /**
@@ -88,18 +89,18 @@
         });
         progress.offsetWidth; /* Repaint */
 
-        setTimeout(function() {
+        Settings.scheduler(function() {
           css(progress, {
             transition: 'all ' + speed + 'ms linear',
             opacity: 0
           });
-          setTimeout(function() {
+          Settings.scheduler(function() {
             NProgress.remove();
             next();
           }, speed);
         }, speed);
       } else {
-        setTimeout(next, speed);
+        Settings.scheduler(next, speed);
       }
     });
 
@@ -121,7 +122,7 @@
     if (!NProgress.status) NProgress.set(0);
 
     var work = function() {
-      setTimeout(function() {
+      Settings.scheduler(function() {
         if (!NProgress.status) return;
         NProgress.trickle();
         work();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "jquery": "^2.1.1",
     "jsdom": "^5.4.3",
     "mocha": "^2.2.4",
-    "mocha-jsdom": "^0.3.0"
+    "mocha-jsdom": "^0.3.0",
+    "testdouble": "^1.9.0"
   },
   "dependencies": {},
   "jspm": {

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@
 
   var root = this;
   var assert = (root.chai || require('chai')).assert;
+  var td = require('testdouble');
 
   describe('NProgress', function() {
     var $, NProgress;
@@ -170,6 +171,16 @@
         assert.equal($("#nprogress .spinner").length, 0);
       });
     });
-  });
 
+    describe('.configure(scheduler)', function() {
+      it('should allow for an alternate scheduler to be provided', function() {
+        var scheduler = td.function('custom scheduler');
+
+        NProgress.configure({ scheduler: scheduler });
+        NProgress.start();
+
+        td.verify(scheduler(td.matchers.isA(Function), td.matchers.isA(Number)));
+      });
+    });
+  });
 })();


### PR DESCRIPTION
While trying to get `nprogress` to play nice with Ember.js, it became necessary to be able to provide an alternate scheduling function, since Ember needs to know about `setTimeout` code.

By default, the code works exactly the same, but if given a `scheduler` function in the configuration, it will use that instead.  This allows Ember to provide it's own scheduling function, allowing the two to play nice together.