### PR TITLE
Replace `turbolinks:visit` with `turbolinks:click`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ Ensure you're using Turbolinks 5+, and use
 this: (explained [here](https://github.com/rstacruz/nprogress/issues/8#issuecomment-239107109))
 
 ~~~ js
-$(document).on('turbolinks:click', function() {
+$(document).on('turbolinks:visit', function() {
   NProgress.start();
 });
 $(document).on('turbolinks:render', function() {


### PR DESCRIPTION
Using `turbolinks:click` works well when you're navigating through links.
This event won't prompt NProgress when the user hits the back button though.

This is important when a certain page doesn't support Turbolinks Page Caching.
Everything else should still work the same.