### PR TITLE
Enable nprogress bar to have multi instance with different parent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: node_js
 node_js: ["6.10.0"]
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: node_js
-node_js: ["iojs"]
+node_js: ["6.10.0"]

--- a/Readme.md
+++ b/Readme.md
@@ -35,44 +35,48 @@ Also available via [unpkg] CDN:
 
 Basic usage
 -----------
+you should instantiate the progress bar
+~~~ js
+var nprogress = NProgress();
+~~~
 
-Simply call `start()` and `done()` to control the progress bar.
+then Simply call `start()` and `done()` to control the progress bar.
 
 ~~~ js
-NProgress.start();
-NProgress.done();
+nprogress.start();
+nprogress.done();
 ~~~
 
 ### Turbolinks (version 5+)
-Ensure you're using Turbolinks 5+, and use 
+Ensure you're using Turbolinks 5+, and use
 this: (explained [here](https://github.com/rstacruz/nprogress/issues/8#issuecomment-239107109))
 
 ~~~ js
 $(document).on('turbolinks:click', function() {
-  NProgress.start();
+  nprogress.start();
 });
 $(document).on('turbolinks:render', function() {
-  NProgress.done();
-  NProgress.remove();
+  nprogress.done();
+  nprogress.remove();
 });
 ~~~
 
 ### Turbolinks (version 3 and below)
-Ensure you're using Turbolinks 1.3.0+, and use 
+Ensure you're using Turbolinks 1.3.0+, and use
 this: (explained [here](https://github.com/rstacruz/nprogress/issues/8#issuecomment-23010560))
 
 ~~~ js
-$(document).on('page:fetch',   function() { NProgress.start(); });
-$(document).on('page:change',  function() { NProgress.done(); });
-$(document).on('page:restore', function() { NProgress.remove(); });
+$(document).on('page:fetch',   function() { nprogress.start(); });
+$(document).on('page:change',  function() { nprogress.done(); });
+$(document).on('page:restore', function() { nprogress.remove(); });
 ~~~
 
 ### Pjax
 Try this: (explained [here](https://github.com/rstacruz/nprogress/issues/22#issuecomment-36540472))
 
 ~~~ js
-$(document).on('pjax:start', function() { NProgress.start(); });
-$(document).on('pjax:end',   function() { NProgress.done();  });
+$(document).on('pjax:start', function() { nprogress.start(); });
+$(document).on('pjax:end',   function() { nprogress.done();  });
 ~~~
 
 Ideas
@@ -91,9 +95,10 @@ __Percentages:__ To set a progress percentage, call `.set(n)`, where *n* is a
 number between `0..1`.
 
 ~~~ js
-NProgress.set(0.0);     // Sorta same as .start()
-NProgress.set(0.4);
-NProgress.set(1.0);     // Sorta same as .done()
+var nprogress = NProgress();
+nprogress.set(0.0);     // Sorta same as .start()
+nprogress.set(0.4);
+nprogress.set(1.0);     // Sorta same as .done()
 ~~~
 
 __Incrementing:__ To increment the progress bar, just use `.inc()`. This
@@ -101,13 +106,13 @@ increments it with a random amount. This will never get to 100%: use it for
 every image load (or similar).
 
 ~~~ js
-NProgress.inc();
+nprogress.inc();
 ~~~
 
 If you want to increment by a specific value, you can pass that as a parameter:
 
 ~~~ js
-NProgress.inc(0.2);    // This will get the current status value and adds 0.2 until status is 0.994
+nprogress.inc(0.2);    // This will get the current status value and adds 0.2 until status is 0.994
 ~~~
 
 __Force-done:__ By passing `true` to `done()`, it will show the progress bar
@@ -115,7 +120,7 @@ even if it's not being shown. (The default behavior is that *.done()* will not
     do anything if *.start()* isn't called)
 
 ~~~ js
-NProgress.done(true);
+nprogress.done(true);
 ~~~
 
 __Get the status value:__ To get the status value, use `.status`
@@ -127,7 +132,7 @@ Configuration
 Changes the minimum percentage used upon starting. (default: `0.08`)
 
 ~~~ js
-NProgress.configure({ minimum: 0.1 });
+nprogress.configure({ minimum: 0.1 });
 ~~~
 
 #### `template`
@@ -136,7 +141,7 @@ bar working, keep an element with `role='bar'` in there. See the [default templa
 for reference.
 
 ~~~ js
-NProgress.configure({
+nprogress.configure({
   template: "<div class='....'>...</div>"
 });
 ~~~
@@ -146,37 +151,45 @@ Adjust animation settings using *easing* (a CSS easing string)
 and *speed* (in ms). (default: `ease` and `200`)
 
 ~~~ js
-NProgress.configure({ easing: 'ease', speed: 500 });
+nprogress.configure({ easing: 'ease', speed: 500 });
 ~~~
 
 #### `trickle`
 Turn off the automatic incrementing behavior by setting this to `false`. (default: `true`)
 
 ~~~ js
-NProgress.configure({ trickle: false });
+nprogress.configure({ trickle: false });
 ~~~
 
 #### `trickleSpeed`
 Adjust how often to trickle/increment, in ms.
 
 ~~~ js
-NProgress.configure({ trickleSpeed: 200 });
+nprogress.configure({ trickleSpeed: 200 });
 ~~~
 
 #### `showSpinner`
 Turn off loading spinner by setting it to false. (default: `true`)
 
 ~~~ js
-NProgress.configure({ showSpinner: false });
+nprogress.configure({ showSpinner: false });
 ~~~
 
 #### `parent`
 specify this to change the parent container. (default: `body`)
 
 ~~~ js
-NProgress.configure({ parent: '#container' });
+nprogress.configure({ parent: '#container' });
 ~~~
 
+Also this is useful when you want to have multi progress bar in your page you need to give different parent for each
+~~~ js
+var nprogress1 = NProgress();
+var nprogress2 = NProgress();
+
+nprogress1.configure({ parent: '#container1' });
+nprogress2.configure({ parent: '#container2' });
+~~~
 Customization
 -------------
 
@@ -204,6 +217,7 @@ __Chat__: join us at gitter.im.<br>
 [![Chat](http://img.shields.io/badge/gitter-rstacruz/nprogress-brightgreen.svg)]( https://gitter.im/rstacruz/nprogress )
 
 [default template]: https://github.com/rstacruz/nprogress/blob/master/nprogress.js#L31
+
 [Turbolinks]: https://github.com/rails/turbolinks
 [nprogress.js]: http://ricostacruz.com/nprogress/nprogress.js
 [nprogress.css]: http://ricostacruz.com/nprogress/nprogress.css

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "nprogress",
   "repo": "rstacruz/nprogress",
   "description": "slim progress bar",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "keywords": [
     "progress",
     "bar",

--- a/nprogress.js
+++ b/nprogress.js
@@ -4,11 +4,11 @@
 ;(function(root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(factory);
+    define(function() {return factory});
   } else if (typeof exports === 'object') {
-    module.exports = factory();
+    module.exports = factory;
   } else {
-    root.NProgress = factory();
+    root.NProgress = factory;
   }
 
 })(this, function() {
@@ -217,12 +217,21 @@
   })();
 
   /**
+   * (Internal) get the rendered element
+   */
+
+  NProgress.getElement = function() {
+    return document.querySelector(Settings.parent + ' #nprogress');
+  }
+
+
+  /**
    * (Internal) renders the progress bar markup based on the `template`
    * setting.
    */
 
   NProgress.render = function(fromStart) {
-    if (NProgress.isRendered()) return document.getElementById('nprogress');
+    if (NProgress.isRendered()) return NProgress.getElement();
 
     addClass(document.documentElement, 'nprogress-busy');
 
@@ -260,7 +269,7 @@
   NProgress.remove = function() {
     removeClass(document.documentElement, 'nprogress-busy');
     removeClass(document.querySelector(Settings.parent), 'nprogress-custom-parent');
-    var progress = document.getElementById('nprogress');
+    var progress = NProgress.getElement();
     progress && removeElement(progress);
   };
 
@@ -269,7 +278,7 @@
    */
 
   NProgress.isRendered = function() {
-    return !!document.getElementById('nprogress');
+    return !!NProgress.getElement();
   };
 
   /**

--- a/nprogress.js
+++ b/nprogress.js
@@ -267,6 +267,7 @@
    */
 
   NProgress.remove = function() {
+    NProgress.status = null;
     removeClass(document.documentElement, 'nprogress-busy');
     removeClass(document.querySelector(Settings.parent), 'nprogress-custom-parent');
     var progress = NProgress.getElement();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nprogress",
   "author": "Rico Sta. Cruz <hi@ricostacruz.com>",
   "description": "Simple slim progress bars",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/rstacruz/nprogress.git"

--- a/test/test.js
+++ b/test/test.js
@@ -7,11 +7,12 @@
   var assert = (root.chai || require('chai')).assert;
 
   describe('NProgress', function() {
-    var $, NProgress;
+    var $, NProgress, NProgressModule;
 
     beforeEach(function() {
       $ = root.jQuery || require('jquery');
-      NProgress = root.NProgress || require('../nprogress');
+      NProgressModule = root.NProgress || require('../nprogress');
+      NProgress = NProgressModule();
 
       this.settings = $.extend({}, NProgress.settings);
     });
@@ -26,13 +27,12 @@
     });
 
     describe('.set()', function() {
-      it('.set(0) must render', function(done) {
+      it('.set(0) must render', function() {
         NProgress.set(0);
         assert.equal($("#nprogress").length, 1);
         assert.equal($("#nprogress .bar").length, 1);
         assert.equal($("#nprogress .peg").length, 1);
         assert.equal($("#nprogress .spinner").length, 1);
-        done();
       });
 
       it('.set(1) should appear and disappear', function(done) {
@@ -79,25 +79,27 @@
       it('must be attached to specified parent', function() {
         var test = $('<div>', {id: 'test'}).appendTo('body');
         NProgress.configure({parent: '#test'});
+
         NProgress.start();
+
         assert.isTrue($("#nprogress").parent().is(test));
         assert.isTrue($(NProgress.settings.parent).hasClass("nprogress-custom-parent"));
+
+        test.remove();
       });
     });
 
     // ----
 
     describe('.done()', function() {
-      it('must not render without start', function(done) {
+      it('must not render without start', function() {
         NProgress.done();
         assert.equal($("#nprogress").length, 0);
-        done();
       });
 
-      it('.done(true) must render', function(done) {
+      it('.done(true) must render', function() {
         NProgress.done(true);
         assert.equal($("#nprogress").length, 1);
-        done();
       });
     });
 
@@ -170,6 +172,73 @@
         assert.equal($("#nprogress .spinner").length, 0);
       });
     });
+
+
+    describe('Tests having multi instance with different parent', function() {
+        var parent1;
+        var parent2;
+
+        beforeEach(function() {
+            parent1 = $('<div>', {id: 'parent1'}).appendTo('body');
+            parent2 = $('<div>', {id: 'parent2'}).appendTo('body');
+        });
+
+
+        afterEach(function() {
+            parent1.remove();
+            parent2.remove();
+        });
+
+
+        it('should render 2 progress bar', function() {
+            var nprogress1 = NProgressModule();
+            var nprogress2 = NProgressModule();
+            nprogress1.configure({parent: '#parent1'});
+            nprogress2.configure({parent: '#parent2'});
+
+            nprogress1.set(0);
+            nprogress2.set(0);
+
+            assert.equal($("#parent1 #nprogress").length, 1);
+            assert.equal($("#parent2 #nprogress").length, 1);
+        });
+
+
+        it('should not affect each other after multi set', function(done) {
+            var nprogress1 = NProgressModule();
+            var nprogress2 = NProgressModule();
+            nprogress1.configure({parent: '#parent1'});
+            nprogress2.configure({parent: '#parent2', speed: 10});
+
+            nprogress1.set(0);
+            nprogress2.set(0).set(1);
+
+            assert.equal($("#parent1 #nprogress").length, 1);
+            assert.equal($("#parent2 #nprogress").length, 1);
+
+            setTimeout(function() {
+              assert.equal($("#parent2 #nprogress").length, 0);
+              done();
+            }, 70);
+        });
+
+
+        it('should not affect each other when removing one', function() {
+            var nprogress1 = NProgressModule();
+            var nprogress2 = NProgressModule();
+            nprogress1.configure({parent: '#parent1'});
+            nprogress2.configure({parent: '#parent2', speed: 10});
+
+            nprogress1.set(0);
+            nprogress2.set(0);
+
+            assert.equal($("#parent1 #nprogress").length, 1);
+            assert.equal($("#parent2 #nprogress").length, 1);
+
+            nprogress1.remove();
+            assert.equal($("#parent1 #nprogress").length, 0);
+        });
+    })
   });
 
 })();

--- a/test/test.js
+++ b/test/test.js
@@ -114,6 +114,20 @@
         assert.isFalse(parent.hasClass('nprogress-custom-parent'));
         assert.equal(parent.find('#nprogress').length, 0);
       });
+
+
+      it('should be removed from the parent even after trickleSpeed', function(done) {
+        NProgress.start();
+
+        NProgress.remove();
+
+        var parent = $(NProgress.settings.parent);
+        setTimeout(function() {
+          assert.isFalse(parent.hasClass('nprogress-custom-parent'));
+          assert.equal(parent.find('#nprogress').length, 0);
+          done();
+        }, NProgress.settings.trickleSpeed + 1);        
+      });
     });
 
     // ----


### PR DESCRIPTION
# THIS IS A BREAKING CHANGE
In this pull request the library will be able to render many progress bar with different parent. This is useful when you have a page with many components each one is loading on it own. there no need for a progress bar that wait for all, but rather each component have it is own progress bar.