### PR TITLE
Remove incorrect ARIA roles

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -24,10 +24,10 @@
     trickle: true,
     trickleSpeed: 200,
     showSpinner: true,
-    barSelector: '[role="bar"]',
-    spinnerSelector: '[role="spinner"]',
+    barSelector: 'div.bar',
+    spinnerSelector: 'div.spinner',
     parent: 'body',
-    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
+    template: '<div class="bar"><div class="peg"></div></div><div class="spinner"><div class="spinner-icon"></div></div>'
   };
 
   /**


### PR DESCRIPTION
This library currently uses invalid ARIA roles, instead use class names to select items.
