### PR TITLE
When parent is not set, then fallback to document.body

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -256,6 +256,11 @@
       spinner && removeElement(spinner);
     }
 
+    // fallback to body, if DOM element hasn't been added in DOM yet
+    if (!document.querySelector(Settings.parent)) {
+      parent = document.body;
+    }
+
     if (parent != document.body) {
       addClass(parent, 'nprogress-custom-parent');
     }


### PR DESCRIPTION
Under some conditions in React, it might be that the parent hasn't been added in DOM yet. In this case, instead of failing, we can use the document.body.